### PR TITLE
refactor: change Nord theme author name from hydino2085143 to Derpitron

### DIFF
--- a/themes/Breeze-Dark/preview-breeze-dark.png.license
+++ b/themes/Breeze-Dark/preview-breeze-dark.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Catppuccin-Frappe/preview-catppuccin-frappe.png.license
+++ b/themes/Catppuccin-Frappe/preview-catppuccin-frappe.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Catppuccin-Latte/preview-catppuccin-latte.png.license
+++ b/themes/Catppuccin-Latte/preview-catppuccin-latte.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Catppuccin-Macchiato/preview-catppuccin-macchiato.png.license
+++ b/themes/Catppuccin-Macchiato/preview-catppuccin-macchiato.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Catppuccin-Mocha/preview-catppuccin-mocha.png.license
+++ b/themes/Catppuccin-Mocha/preview-catppuccin-mocha.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Dracula/preview-dracula.png.license
+++ b/themes/Dracula/preview-dracula.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Fluent-Dark/preview-fluent-dark.png.license
+++ b/themes/Fluent-Dark/preview-fluent-dark.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Nord/README.md
+++ b/themes/Nord/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 hydino2085143 <priya.aravamuthan@protonmail.com>
+SPDX-FileCopyrightText: 2022 Derpitron <priya.aravamuthan@protonmail.com>
 
 SPDX-License-Identifier: CC0-1.0
 
@@ -17,7 +17,7 @@ Nord
 GPL-3.0-or-later License
 
 Copyright (c) 2016 Nord Theme
-Copyright (c) 2022 hydino2085143
+Copyright (c) 2022 Derpitron
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/themes/Nord/preview-nord.png.license
+++ b/themes/Nord/preview-nord.png.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 SPDX-License-Identifier: CC0-1.0

--- a/themes/Nord/theme.json.license
+++ b/themes/Nord/theme.json.license
@@ -1,4 +1,4 @@
 SPDX-FileCopyrightText: 2016 Nord Theme
-SPDX-FileCopyrightText: 2022 hydino2085143
+SPDX-FileCopyrightText: 2022 Derpitron
 
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/themes/Nord/themeStyle.css
+++ b/themes/Nord/themeStyle.css
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 hydino2085143
+ * SPDX-FileCopyrightText: 2022 Derpitron
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */


### PR DESCRIPTION
I have changed my Github username recently, so I would like that to be reflected in the license files.

All code and assets are unchanged, only license files and author attribution for Nord theme has been updated.

I hope you can understand.