### PR TITLE
make fluent inherit from flat white instead of legacy

### DIFF
--- a/icons/Fluent-Dark/index.theme
+++ b/icons/Fluent-Dark/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Fluent Dark
 Comment=Fluent Dark icons
-Inherits=multimc
+Inherits=flat_white
 Directories=scalable
 
 [scalable]


### PR DESCRIPTION
this makes the icon theme look better if there's no icon in the theme