### PR TITLE
fix: fix instance renaming styles for Fluent-Dark and Borest themes

### DIFF
--- a/themes/Borest/themeStyle.css
+++ b/themes/Borest/themeStyle.css
@@ -814,25 +814,21 @@ QTextEdit,
 QPlainTextEdit {
     background-color: rgba(255, 255, 255, 16);
     border: 1px solid rgba(255, 255, 255, 5);
-    border-radius: 7px;
     border-bottom: 1px solid #9ab8e6;
-    padding: 5px;
 }
 
 QTextEdit:hover,
 QPlainTextEdit:hover {
-    background-color: rgba(255, 255, 255, 20);
-    border: 1px solid rgba(255, 255, 255, 10);
-    border-bottom: 1px solid #9ab8e6;
+    background-color: rgba(0, 0, 0, 255);
 }
 
 QTextEdit:focus,
 QPlainTextEdit:focus {
-    border-bottom: 2px solid #60cdff;
-    background-color: rgba(255, 255, 255, 5);
-    border-top: 1px solid rgba(255, 255, 255, 7);
-    border-left: 1px solid rgba(255, 255, 255, 7);
-    border-right: 1px solid rgba(255, 255, 255, 7);
+    border-bottom: 1px solid #60cdff;
+    background-color: rgba(0, 0, 0, 255);
+    border-top: 1px solid #60cdff;
+    border-left: 1px solid #60cdff;
+    border-right: 1px solid #60cdff;
 }
 
 QTextEdit:disabled,

--- a/themes/Fluent-Dark/themeStyle.css
+++ b/themes/Fluent-Dark/themeStyle.css
@@ -812,25 +812,21 @@ QTextEdit,
 QPlainTextEdit {
     background-color: rgba(255, 255, 255, 16);
     border: 1px solid rgba(255, 255, 255, 5);
-    border-radius: 7px;
     border-bottom: 1px solid #707070;
-    padding: 5px;
 }
 
 QTextEdit:hover,
 QPlainTextEdit:hover {
-    background-color: rgba(255, 255, 255, 20);
-    border: 1px solid rgba(255, 255, 255, 10);
-    border-bottom: 1px solid #707070;
+    background-color: rgba(0, 0, 0, 255);
 }
 
 QTextEdit:focus,
 QPlainTextEdit:focus {
-    border-bottom: 2px solid #60cdff;
-    background-color: rgba(255, 255, 255, 5);
-    border-top: 1px solid rgba(255, 255, 255, 7);
-    border-left: 1px solid rgba(255, 255, 255, 7);
-    border-right: 1px solid rgba(255, 255, 255, 7);
+    border-bottom: 1px solid #60cdff;
+    background-color: rgba(0, 0, 0, 255);
+    border-top: 1px solid #60cdff;
+    border-left: 1px solid #60cdff;
+    border-right: 1px solid #60cdff;
 }
 
 QTextEdit:disabled,


### PR DESCRIPTION
Fixed issue https://github.com/PrismLauncher/Themes/issues/25

Before:

![Fluent-Dark](https://github.com/user-attachments/assets/03a7bff8-2bec-49b3-a024-fb4ba4861c8a)
![Borest](https://github.com/user-attachments/assets/af2492ef-7e2f-4731-a1e3-5bebece5b153)

After:

![Borest](https://github.com/user-attachments/assets/5d31b43b-da0f-4a35-af5f-31ed64c65d7b)
![Fluent-Dark](https://github.com/user-attachments/assets/afed4960-d416-4541-a9b2-98296ba90880)
