### PR TITLE
Change Fluent and Borest theme to fix bugs and match upstream

### DIFF
--- a/themes/Borest/themeStyle.css
+++ b/themes/Borest/themeStyle.css
@@ -19,7 +19,7 @@ QDockWidget {
 QWidget {
     border-color: rgba(255, 255, 255, 8);
     font-family: "Segoe UI Variable Text Semibold", serif;
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 QObject,
@@ -59,7 +59,7 @@ QToolBar::separator {
 QToolButton {
     background-color: rgba(255, 255, 255, 0);
 	border: 1px solid transparent;
-    border-radius: 5px;
+    border-radius: 4px;
     padding: 2px;
     margin: 1px; 
     margin-left: 5px;
@@ -141,7 +141,7 @@ QMenu::icon {
 QMenu::item {
     background-color: transparent;
     padding: 5px 15px;
-    border-radius: 5px;
+    border-radius: 4px;
     min-width: 60px;
     margin: 3px;
 }
@@ -172,7 +172,7 @@ QMenu::item:disabled {
 /*PUSHBUTTON*/
 QPushButton {
     background-color: rgba(255, 255, 255, 18);
-    border-radius: 5px;
+    border-radius: 4px;
     color: #ffffff;
     padding: 7px 20px; 
     margin-right: 5px;
@@ -196,20 +196,18 @@ QPushButton:disabled {
 
 /*GROUPBOX*/
 QGroupBox {
-    border-radius: 5px;
-    border: 1px solid rgba(255, 255, 255, 3);
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.23);
     margin-top: 23px;
-    background-color: rgba(255, 255, 255, 5);
+    background-color: rgba(255, 255, 255, 0.052);
 }
 
 QGroupBox::title {
     subcontrol-origin: margin;
     subcontrol-position: top left;
-    background-color: rgba(255, 255, 255, 16);
-    padding: 3px 15px;
-    margin-left: 5px;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+	font-size: 24px;
+	font-weight: bold;
+	color: #FFFFFF;
 }
 
 QGroupBox::title::disabled {
@@ -230,7 +228,7 @@ QListView::item {
     padding-top: 5px;
     padding-bottom: 5px; 
     margin-bottom: 5px;
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 QListView::item:hover {
@@ -238,7 +236,7 @@ QListView::item:hover {
 }
 
 QListView::item:selected {
-    border-radius: 5px;
+    border-radius: 4px;
     outline: 0;
     background-color: rgba(255, 255, 255, 13);
     border-color: rgba(255, 255, 255, 0);
@@ -341,20 +339,21 @@ QHeaderView::down-arrow {
 
 /*TABWIDGET*/
 QTabWidget::pane {
-    border: 0px solid rgba(255, 255, 255, 40);
-    border-radius: 5px;
+    border: 0px solid rgba(255, 255, 255, 0);
+    border-radius: 8px;
+    background-color: rgba(255, 255, 255, 0.035);
 }
 
 QTabWidget::tab-bar {
-    left: 15px;
+    left: 8px;
 }
 
 QTabBar::tab {
     background-color: rgba(255, 255, 255, 0);
     padding: 8px 15px;
     margin-right: 2px;
-    margin-bottom: 2px;
-    border-radius: 5px;
+    margin-bottom: 4px;
+    border-radius: 4px;
 }
 
 QTabBar::tab:hover {
@@ -362,7 +361,7 @@ QTabBar::tab:hover {
 }
 
 QTabBar::tab:selected {
-    background-color: rgba(255, 255, 255, 16);
+    background-color: rgba(255, 255, 255, 0.035);
 }
 
 QTabBar::tab:disabled {
@@ -505,7 +504,7 @@ QProgressBar::chunk {
 QSpinBox {
     background-color: rgba(255, 255, 255, 10);
     border: 1px solid rgba(255, 255, 255, 8);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -591,7 +590,7 @@ QSpinBox::down-button:disabled {
 QDoubleSpinBox {
     background-color: rgba(255, 255, 255, 10);
     border: 1px solid rgba(255, 255, 255, 8);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -677,7 +676,7 @@ QDoubleSpinBox::down-button:disabled {
 QDateTimeEdit {
     background-color: rgba(255, 255, 255, 10);
     border: 1px solid rgba(255, 255, 255, 8);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -763,7 +762,7 @@ QDateTimeEdit::down-button:disabled {
 /*COMBOBOX*/
 QComboBox {
     background-color: rgba(255, 255, 255, 18);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 5px;
     padding-bottom: 6px;
@@ -851,7 +850,7 @@ QLineEdit {
     background-color: rgba(255, 255, 255, 16);
     border: 1px solid rgba(255, 255, 255, 5);
     color: #ffffff;
-    border-radius: 5px;
+    border-radius: 4px;
     border-bottom: 1px solid #9ab8e6;
     padding-left: 5px;
     padding-top: 4px;
@@ -1041,7 +1040,6 @@ QCheckBox,
 QAbstractCheckBox,
 QTreeView::indicator,
 QRadioButton {
-    min-height: 20px;
     font-style: normal;
 }
 

--- a/themes/Fluent-Dark/themeStyle.css
+++ b/themes/Fluent-Dark/themeStyle.css
@@ -192,19 +192,17 @@ QPushButton:disabled {
 /*GROUPBOX*/
 QGroupBox {
     border-radius: 5px;
-    border: 1px solid rgba(255, 255, 255, 3);
+    border: 0px solid rgba(255, 255, 255, 0);
     margin-top: 23px;
-    background-color: rgba(255, 255, 255, 5);
+    background-color: rgba(255, 255, 255, 0);
 }
 
 QGroupBox::title {
     subcontrol-origin: margin;
     subcontrol-position: top left;
-    background-color: rgba(255, 255, 255, 16);
-    padding: 3px 15px;
-    margin-left: 5px;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+	font-size: 24px;
+	font-weight: bold;
+	color: #FFFFFF;
 }
 
 QGroupBox::title::disabled {
@@ -336,20 +334,23 @@ QHeaderView::down-arrow {
 
 /*TABWIDGET*/
 QTabWidget::pane {
-    border: 0px solid rgba(255, 255, 255, 40);
+    border: 0px solid rgba(255, 255, 255, 0);
     border-radius: 5px;
+    background-color: rgba(255, 255, 255, 16);
 }
 
 QTabWidget::tab-bar {
-    left: 15px;
+	left:5px;
+	height: 100px;
 }
 
 QTabBar::tab {
     background-color: rgba(255, 255, 255, 0);
     padding: 8px 15px;
     margin-right: 2px;
-    margin-bottom: 2px;
-    border-radius: 5px;
+	border-radius: 0px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
 }
 
 QTabBar::tab:hover {

--- a/themes/Fluent-Dark/themeStyle.css
+++ b/themes/Fluent-Dark/themeStyle.css
@@ -14,7 +14,7 @@ QDockWidget {
 QWidget {
     border-color: rgba(255, 255, 255, 8);
     font-family: "Segoe UI Variable Text Semibold", serif;
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 QObject,
@@ -54,7 +54,7 @@ QToolBar::separator {
 QToolButton {
     background-color: rgba(255, 255, 255, 0);
 	border: 1px solid transparent;
-    border-radius: 5px;
+    border-radius: 4px;
     padding: 2px;
     margin: 1px; 
     margin-left: 5px;
@@ -136,7 +136,7 @@ QMenu::icon {
 QMenu::item {
     background-color: transparent;
     padding: 5px 15px;
-    border-radius: 5px;
+    border-radius: 4px;
     min-width: 60px;
     margin: 3px;
 }
@@ -167,7 +167,7 @@ QMenu::item:disabled {
 /*PUSHBUTTON*/
 QPushButton {
     background-color: rgba(255, 255, 255, 18);
-    border-radius: 5px;
+    border-radius: 4px;
     color: #ffffff;
     padding: 7px 20px; 
     margin-right: 5px;
@@ -191,10 +191,10 @@ QPushButton:disabled {
 
 /*GROUPBOX*/
 QGroupBox {
-    border-radius: 5px;
-    border: 0px solid rgba(255, 255, 255, 0);
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.23);
     margin-top: 23px;
-    background-color: rgba(255, 255, 255, 0);
+    background-color: rgba(255, 255, 255, 0.052);
 }
 
 QGroupBox::title {
@@ -223,7 +223,7 @@ QListView::item {
     padding-top: 5px;
     padding-bottom: 5px; 
     margin-bottom: 5px;
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 QListView::item:hover {
@@ -231,7 +231,7 @@ QListView::item:hover {
 }
 
 QListView::item:selected {
-    border-radius: 5px;
+    border-radius: 4px;
     outline: 0;
     background-color: rgba(255, 255, 255, 13);
     border-color: rgba(255, 255, 255, 0);
@@ -335,12 +335,12 @@ QHeaderView::down-arrow {
 /*TABWIDGET*/
 QTabWidget::pane {
     border: 0px solid rgba(255, 255, 255, 0);
-    border-radius: 5px;
-    background-color: rgba(255, 255, 255, 16);
+    border-radius: 8px;
+    background-color: rgba(255, 255, 255, 0.035);
 }
 
 QTabWidget::tab-bar {
-	left:5px;
+	left:8px;
 	height: 100px;
 }
 
@@ -358,7 +358,7 @@ QTabBar::tab:hover {
 }
 
 QTabBar::tab:selected {
-    background-color: rgba(255, 255, 255, 16);
+    background-color: rgba(255, 255, 255, 0.035);
 }
 
 QTabBar::tab:disabled {
@@ -501,7 +501,7 @@ QProgressBar::chunk {
 QSpinBox {
     background-color: rgba(255, 255, 255, 10);
     border: 1px solid rgba(255, 255, 255, 8);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -587,7 +587,7 @@ QSpinBox::down-button:disabled {
 QDoubleSpinBox {
     background-color: rgba(255, 255, 255, 10);
     border: 1px solid rgba(255, 255, 255, 8);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -673,7 +673,7 @@ QDoubleSpinBox::down-button:disabled {
 QDateTimeEdit {
     background-color: rgba(255, 255, 255, 10);
     border: 1px solid rgba(255, 255, 255, 8);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -759,7 +759,7 @@ QDateTimeEdit::down-button:disabled {
 /*COMBOBOX*/
 QComboBox {
     background-color: rgba(255, 255, 255, 18);
-    border-radius: 5px;
+    border-radius: 4px;
     padding-left: 10px;
     padding-top: 5px;
     padding-bottom: 6px;
@@ -847,7 +847,7 @@ QLineEdit {
     background-color: rgba(255, 255, 255, 16);
     border: 1px solid rgba(255, 255, 255, 5);
     color: #ffffff;
-    border-radius: 5px;
+    border-radius: 4px;
     border-bottom: 1px solid #707070;
     padding-left: 5px;
     padding-top: 4px;
@@ -1037,7 +1037,6 @@ QCheckBox,
 QAbstractCheckBox,
 QTreeView::indicator,
 QRadioButton {
-    min-height: 20px;
     font-style: normal;
 }
 


### PR DESCRIPTION
Used WinUI3 Gallery to gauge colors, radii and sizes.

- most radii are now 4px, Some outer panels are 8px (QTabPane)
![image](https://github.com/user-attachments/assets/3293ec54-02d8-4d52-9c61-06ece26022e3)

- TabPane and QGroupBox colors match Fluent colors for Panel and Settings Card
- removed min-height for QLabel to fix some dialog and icon sizes (e.g. about Dialog logo, delete Dialog)

Screenshots:
![image](https://github.com/user-attachments/assets/f2fcafb3-4deb-4b07-b65c-0c03b6d3b404)
![image](https://github.com/user-attachments/assets/97543afc-0220-486f-b459-2e1d2658258f)
![image](https://github.com/user-attachments/assets/652b7b21-47f1-4e29-a1d0-bc4f9780fb54)

